### PR TITLE
Update image_collection.h

### DIFF
--- a/src/eloquent_esp32cam/viz/image_collection.h
+++ b/src/eloquent_esp32cam/viz/image_collection.h
@@ -1,7 +1,7 @@
 #ifndef ELOQUENT_ESP32CAM_VIZ_IMAGE_COLLECTION_H
 #define ELOQUENT_ESP32CAM_VIZ_IMAGE_COLLECTION_H
 
-#include "../camera/Camera.h"
+#include "../camera/camera.h"
 #include "../extra/exception.h"
 #include "../extra/esp32/wifi/sta.h"
 #include "../extra/esp32/http/server.h"


### PR DESCRIPTION
I fixed a spelling mistake in the include path for the camera.h header file. This should fix the build error that was preventing the compiler from finding the header file.