### PR TITLE
Change case of "/Camera.h" so that it correctly compiles

### DIFF
--- a/src/eloquent_esp32cam/jpeg/decoder_gray.h
+++ b/src/eloquent_esp32cam/jpeg/decoder_gray.h
@@ -3,7 +3,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "../camera/Camera.h"
+#include "../camera/camera.h"
 #include "./picojpeg.h"
 #include "../extra/exception.h"
 #include "../extra/benchmark.h"

--- a/src/eloquent_esp32cam/viz/ei/fomo_stream.h
+++ b/src/eloquent_esp32cam/viz/ei/fomo_stream.h
@@ -3,7 +3,7 @@
 #ifndef ELOQUENT_ESP32CAM_VIZ_EI_FOMO_STREAM_H
 #define ELOQUENT_ESP32CAM_VIZ_EI_FOMO_STREAM_H
 
-#include "../../camera/Camera.h"
+#include "../../camera/camera.h"
 #include "../../extra/exception.h"
 #include "../../extra/esp32/http/server.h"
 #include "../../edgeimpulse/fomo.h"

--- a/src/eloquent_esp32cam/viz/face_stream.h
+++ b/src/eloquent_esp32cam/viz/face_stream.h
@@ -1,7 +1,7 @@
 #ifndef ELOQUENT_ESP32CAM_VIZ_FACE_STREAM_H
 #define ELOQUENT_ESP32CAM_VIZ_FACE_STREAM_H
 
-#include "../camera/Camera.h"
+#include "../camera/camera.h"
 #include "../extra/exception.h"
 #include "../extra/esp32/wifi/sta.h"
 #include "../extra/esp32/http/server.h"

--- a/src/eloquent_esp32cam/viz/image_collection.h
+++ b/src/eloquent_esp32cam/viz/image_collection.h
@@ -1,7 +1,7 @@
 #ifndef ELOQUENT_ESP32CAM_VIZ_IMAGE_COLLECTION_H
 #define ELOQUENT_ESP32CAM_VIZ_IMAGE_COLLECTION_H
 
-#include "../camera/Camera.h"
+#include "../camera/camera.h"
 #include "../extra/exception.h"
 #include "../extra/esp32/wifi/sta.h"
 #include "../extra/esp32/http/server.h"


### PR DESCRIPTION
Just minor tidy; only affects case-senstive compilation environments.